### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -14,6 +14,8 @@ jobs:
   build:
     name: Docker build and push image to ACR
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       IMAGE_NAME: paloitinternalregistry.azurecr.io/react-xr-workshop:${{ github.ref_name  }}
 


### PR DESCRIPTION
Potential fix for [https://github.com/palo-it-th/react-xr-workshop/security/code-scanning/1](https://github.com/palo-it-th/react-xr-workshop/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `build` job. Based on the actions performed in the `build` job, it primarily requires access to the repository contents to check out the code. Therefore, the minimal permissions required are `contents: read`. This change ensures that the `build` job does not inherit unnecessary permissions from the repository.

The `permissions` block should be added immediately after the `runs-on` key in the `build` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
